### PR TITLE
Feature/treatment dose observer

### DIFF
--- a/src/vivarium_conic_vitamin_a_supp/components/__init__.py
+++ b/src/vivarium_conic_vitamin_a_supp/components/__init__.py
@@ -1,1 +1,3 @@
 from .vitamin_a_supplementation import MagicWandSupplementationInterventionStepWise
+from .observer import SupplementedDaysObserver
+

--- a/src/vivarium_conic_vitamin_a_supp/components/observer.py
+++ b/src/vivarium_conic_vitamin_a_supp/components/observer.py
@@ -1,0 +1,59 @@
+from collections import Counter
+
+import pandas as pd
+
+from vivarium_public_health.metrics.utilities import QueryString, get_output_template, get_age_bins, get_group_counts
+
+
+class SupplementedDaysObserver:
+
+    configuration_defaults = {
+        'metrics': {
+            'supplemented_days': {
+                'by_age': False,
+                'by_year': False,
+                'by_sex': False
+            }
+        }
+    }
+
+    def __init__(self):
+        self.measure_name = 'supplemented_days'
+
+    @property
+    def name(self, ):
+        return 'supplemented_days_observer'
+
+    def setup(self, builder):
+        self.config = builder.configuration.metrics.supplemented_days
+        self.step_size = builder.time.step_size()
+        self.age_bins = get_age_bins(builder)
+
+        self.lack_of_vitamin_a_supplementation = builder.value.get_value("lack_of_vitamin_a_supplementation.exposure")
+        self.supplemented_days = Counter()
+
+        columns_required = ['tracked', 'alive', 'age', 'sex']  # TODO: do I care
+        self.population_view = builder.population.get_view(columns_required)
+
+        builder.event.register_listener('collect_metrics', self.on_collect_metrics)
+        builder.value.register_value_modifier('metrics', self.metrics)
+
+    def on_collect_metrics(self, event):
+        pop = self.population_view.get(event.index)
+        current_lack_of_supplementation_exposure = self.lack_of_vitamin_a_supplementation(pop.index)
+
+        # cat 1 represents the exposure to lack of vitamin a supplementation
+        # therefore cat 2 is "being supplemented"
+        current_supplemented_pop = pop.loc[current_lack_of_supplementation_exposure == 'cat2']
+
+        config = self.config.to_dict().copy()
+        base_filter = QueryString(f'alive == "alive"')
+        base_key = get_output_template(**config).substitute(measure=self.measure_name, year=event.time.year)
+        current_supplemented_count = get_group_counts(current_supplemented_pop, base_filter, base_key,
+                                              config, self.age_bins)
+        current_supplemented_count = {k: v * self.step_size().days for k, v in current_supplemented_count.items()}
+        self.supplemented_days.update(current_supplemented_count)
+
+    def metrics(self, index: pd.Index, metrics: dict):
+        metrics.update(self.supplemented_days)
+        return metrics

--- a/src/vivarium_conic_vitamin_a_supp/components/observer.py
+++ b/src/vivarium_conic_vitamin_a_supp/components/observer.py
@@ -32,7 +32,11 @@ class SupplementedDaysObserver:
         self.lack_of_vitamin_a_supplementation = builder.value.get_value("lack_of_vitamin_a_supplementation.exposure")
         self.supplemented_days = Counter()
 
-        columns_required = ['tracked', 'alive', 'age', 'sex']  # TODO: do I care
+        columns_required = ['tracked', 'alive']
+        if self.config.by_age:
+            columns_required += ['age']
+        if self.config.by_sex:
+            columns_required += ['sex']
         self.population_view = builder.population.get_view(columns_required)
 
         builder.event.register_listener('collect_metrics', self.on_collect_metrics)

--- a/src/vivarium_conic_vitamin_a_supp/model_specifications/vivarium_conic_vitamin_a_supp.yaml
+++ b/src/vivarium_conic_vitamin_a_supp/model_specifications/vivarium_conic_vitamin_a_supp.yaml
@@ -27,6 +27,7 @@ components:
             - CategoricalRiskObserver('risk_factor.vitamin_a_deficiency')
     vivarium_conic_vitamin_a_supp.components:
         - MagicWandSupplementationInterventionStepWise()
+        - SupplementedDaysObserver()
 
 
 configuration:
@@ -78,3 +79,7 @@ configuration:
             by_age: False
             by_sex: False
             by_year: True
+        supplemented_days:
+            by_age: False
+            by_sex: False
+            by_year: False


### PR DESCRIPTION
This observer is intended to count time supplemented in days. Aditya will use this for preliminary costing.

We do this by checking exposure to lack of vitamin A supplementation. If it comes back cat2 (not exposed), then they are being supplemented.